### PR TITLE
feat: add middleware to fetch mars weather

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^5.9.0",
+        "node-fetch": "^3.3.2",
         "nodemailer": "^6.9.7",
         "reflect-metadata": "^0.1.13",
         "swagger-jsdoc": "^6.2.8",
@@ -248,6 +249,44 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -1321,6 +1360,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -1869,6 +1916,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1958,6 +2027,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2937,42 +3017,39 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
         }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/nodemailer": {
@@ -4478,6 +4555,14 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^5.9.0",
+    "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.7",
     "reflect-metadata": "^0.1.13",
     "swagger-jsdoc": "^6.2.8",

--- a/src/middleware/getWeatherData.ts
+++ b/src/middleware/getWeatherData.ts
@@ -3,17 +3,15 @@ import { getWeather } from '../utils/getWeather';
 import { SolData } from '../types/ApiResponse';
 
 /**
- * Middleware assíncrono para obter dados meteorológicos de Marte.
- * Este middleware tenta buscar os dados do clima marciano usando a função `getWeather`.
- * Em caso de sucesso, passa o controle para o próximo middleware.
- * Se ocorrer um erro durante a busca, o erro é capturado e passado para o próximo
- * middleware de tratamento de erros.
- *
- * @param {Request} req - O objeto da requisição Express.
- * @param {Response} res - O objeto da resposta Express.
- * @param {NextFunction} next - A função callback para passar o controle para o próximo middleware.
- * @returns {Promise<void>} - Uma promessa que resolve quando o middleware termina a execução.
+ * Asynchronous middleware to fetch Martian weather data.
+ * This middleware attempts to fetch Martian weather data using the `getWeather` function.
+ * If successful, it passes control to the next middleware.
+ * @param {Request} req - The Express request object.
+ * @param {Response} res - The Express response object.
+ * @param {NextFunction} next - The callback function to pass control to the next middleware.
+ * @returns {Promise<void>} - A promise that resolves when the middleware finishes execution.
  */
+
 export const getWeatherData = async (
   req: Request,
   res: Response,
@@ -22,11 +20,7 @@ export const getWeatherData = async (
   const url =
     'https://mars.nasa.gov/rss/api/?feed=weather&category=msl&feedtype=json' as string;
 
-  try {
-    await getWeather(url);
+  await getWeather(url);
 
-    next();
-  } catch (error) {
-    next(error);
-  }
+  next();
 };

--- a/src/middleware/getWeatherData.ts
+++ b/src/middleware/getWeatherData.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction } from 'express';
+import { getWeather } from '../utils/getWeather';
+import { SolData } from '../types/ApiResponse';
+
+/**
+ * Middleware assíncrono para obter dados meteorológicos de Marte.
+ * Este middleware tenta buscar os dados do clima marciano usando a função `getWeather`.
+ * Em caso de sucesso, passa o controle para o próximo middleware.
+ * Se ocorrer um erro durante a busca, o erro é capturado e passado para o próximo
+ * middleware de tratamento de erros.
+ *
+ * @param {Request} req - O objeto da requisição Express.
+ * @param {Response} res - O objeto da resposta Express.
+ * @param {NextFunction} next - A função callback para passar o controle para o próximo middleware.
+ * @returns {Promise<void>} - Uma promessa que resolve quando o middleware termina a execução.
+ */
+export const getWeatherData = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<SolData | void> => {
+  const url =
+    'https://mars.nasa.gov/rss/api/?feed=weather&category=msl&feedtype=json' as string;
+
+  try {
+    await getWeather(url);
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/types/ApiResponse.ts
+++ b/src/types/ApiResponse.ts
@@ -1,0 +1,19 @@
+export interface MarsWeatherApiResponse {
+  soles?: MarsSolData[];
+}
+
+export interface MarsSolData {
+  sol: string;
+  terrestrial_date: string;
+  min_temp: string;
+  max_temp: string;
+}
+
+interface SolTemperatureData {
+  sol: string;
+  date: string;
+  minTemp: number;
+  maxTemp: number;
+}
+
+export type SolData = SolTemperatureData[];

--- a/src/utils/getWeather.ts
+++ b/src/utils/getWeather.ts
@@ -1,0 +1,42 @@
+import fetch from 'node-fetch';
+import {
+  MarsSolData,
+  MarsWeatherApiResponse,
+  SolData
+} from '../types/ApiResponse';
+
+/**
+ * Recupera de forma assíncrona os dados meteorológicos do URL fornecido e os processa para retornar os primeiros 14 dias solares marcianos (Sols) de dados de temperatura.
+ *
+ * @param {string} url - O endpoint URL de onde os dados meteorológicos de Marte serão obtidos.
+ * @returns {Promise<SolData>} Uma promessa que se resolve em um array de objetos SolData, cada um contendo informações sobre um único dia solar marciano (Sol).
+ * O SolData inclui o número do Sol, a data terrestre e as temperaturas mínima e máxima desse dia.
+ * @throws Lança um erro com o código de status HTTP se a resposta da chamada fetch não for 'ok'.
+ * @example
+ * // Exemplo de uso
+ * getWeather('https://api.marsweather.app/v1/latest/').then(data => {
+ *   console.log(data);
+ * });
+ */
+export const getWeather = async (url: string): Promise<SolData> => {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Erro HTTP! Status: ${response.status}`);
+    }
+    const data: MarsWeatherApiResponse = await response.json();
+
+    const first14Soles: MarsSolData[] = data.soles.slice(0, 14);
+
+    const sols: SolData = first14Soles.map((sol) => ({
+      sol: sol.sol,
+      date: sol.terrestrial_date,
+      minTemp: parseInt(sol.min_temp),
+      maxTemp: parseInt(sol.max_temp)
+    }));
+    return sols;
+  } catch (error) {
+    console.error('Erro ao buscar os dados meteorológicos:', error);
+    return [];
+  }
+};

--- a/src/utils/getWeather.ts
+++ b/src/utils/getWeather.ts
@@ -6,37 +6,32 @@ import {
 } from '../types/ApiResponse';
 
 /**
- * Recupera de forma assíncrona os dados meteorológicos do URL fornecido e os processa para retornar os primeiros 14 dias solares marcianos (Sols) de dados de temperatura.
+ * Asynchronously retrieves weather data from the provided URL and processes it to return the first 14 Martian solar days (Sols) of temperature data.
  *
- * @param {string} url - O endpoint URL de onde os dados meteorológicos de Marte serão obtidos.
- * @returns {Promise<SolData>} Uma promessa que se resolve em um array de objetos SolData, cada um contendo informações sobre um único dia solar marciano (Sol).
- * O SolData inclui o número do Sol, a data terrestre e as temperaturas mínima e máxima desse dia.
- * @throws Lança um erro com o código de status HTTP se a resposta da chamada fetch não for 'ok'.
+ * @param {string} url - The endpoint URL from where the Martian weather data will be fetched.
+ * @returns {Promise<SolData>} A promise that resolves to an array of SolData objects, each containing information about a single Martian solar day (Sol).
+ * SolData includes the Sol number, the terrestrial date, and the minimum and maximum temperatures of that day.
+ * @throws Throws an error with the HTTP status code if the response from the fetch call is not 'ok'.
  * @example
- * // Exemplo de uso
+ * // Usage example
  * getWeather('https://api.marsweather.app/v1/latest/').then(data => {
  *   console.log(data);
  * });
  */
 export const getWeather = async (url: string): Promise<SolData> => {
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Erro HTTP! Status: ${response.status}`);
-    }
-    const data: MarsWeatherApiResponse = await response.json();
-
-    const first14Soles: MarsSolData[] = data.soles.slice(0, 14);
-
-    const sols: SolData = first14Soles.map((sol) => ({
-      sol: sol.sol,
-      date: sol.terrestrial_date,
-      minTemp: parseInt(sol.min_temp),
-      maxTemp: parseInt(sol.max_temp)
-    }));
-    return sols;
-  } catch (error) {
-    console.error('Erro ao buscar os dados meteorológicos:', error);
-    return [];
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP Error! Status: ${response.status}`);
   }
+  const data: MarsWeatherApiResponse = await response.json();
+
+  const first14Soles: MarsSolData[] = data.soles.slice(0, 14);
+
+  const sols: SolData = first14Soles.map((sol) => ({
+    sol: sol.sol,
+    date: sol.terrestrial_date,
+    minTemp: parseInt(sol.min_temp),
+    maxTemp: parseInt(sol.max_temp)
+  }));
+  return sols;
 };


### PR DESCRIPTION
Implementação de um middleware com um método auxiliar para buscar os dados meteorológios de Marte. O método busca as 14 últimas medições realizadas e retorna uma lista com os objetos contendo o sol, a data e as temperaturas mínima e máxima.