### PR TITLE
docfix: Adequa Swagger ao novo formato da Response

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -34,13 +34,28 @@ export const swaggerConfig: swaggerJSDoc.OAS3Options = {
                   type: 'object',
                   properties: {
                     min: {
-                      type: 'number'
+                      type: 'object',
+                      properties: {
+                        value: {
+                          type: 'number'
+                        },
+                        variation: {
+                          type: 'number',
+                          required: false
+                        }
+                      }
                     },
                     max: {
-                      type: 'number'
-                    },
-                    variation: {
-                      type: 'number'
+                      type: 'object',
+                      properties: {
+                        value: {
+                          type: 'number'
+                        },
+                        variation: {
+                          type: 'number',
+                          required: false
+                        }
+                      }
                     }
                   }
                 },
@@ -48,13 +63,28 @@ export const swaggerConfig: swaggerJSDoc.OAS3Options = {
                   type: 'object',
                   properties: {
                     min: {
-                      type: 'number'
+                      type: 'object',
+                      properties: {
+                        value: {
+                          type: 'number'
+                        },
+                        variation: {
+                          type: 'number',
+                          required: false
+                        }
+                      }
                     },
                     max: {
-                      type: 'number'
-                    },
-                    variation: {
-                      type: 'number'
+                      type: 'object',
+                      properties: {
+                        value: {
+                          type: 'number'
+                        },
+                        variation: {
+                          type: 'number',
+                          required: false
+                        }
+                      }
                     }
                   }
                 }
@@ -64,7 +94,8 @@ export const swaggerConfig: swaggerJSDoc.OAS3Options = {
               type: 'string'
             },
             solDate: {
-              type: 'number'
+              type: 'integer',
+              format: 'int32'
             }
           }
         },


### PR DESCRIPTION
Põe a _Variation_ relativa a cada temperatura.
Explicita que o _dia solar_ tem que ter formato inteiro (_OBS_: Não conflita com o _number_ do JS, serve apenas como referencial).