### PR TITLE
Bugfix: Utiliza a URL do Frontend como reset link

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       DB_DATABASE: orion
       DB_CONNECTION_STRING: mongodb://orion_root:j5m966qp7jiypfda@orion-mongo:27017
       JWT_SECRET: AFdMvt5jwI5n9LNHN0MxPxLWm9nwtsb8M2Q9yYBYzbRGz03ris
-      FRONTEND_URL: http://localhost:8080
+      FRONTEND_URL: http://localhost:4200
     networks:
       - orion-connect
   

--- a/src/controller/ForgotPasswordController.ts
+++ b/src/controller/ForgotPasswordController.ts
@@ -93,7 +93,7 @@ export class ForgotPasswordController {
     }
 
     const email: string = user?.email;
-    const resetURL: string = `${process.env.FRONTEND_URL}/reset-password/${user?._id}/${resetToken}`;
+    const resetURL: string = `${process.env.FRONTEND_URL}/auth/reset-password/${user?._id}/${resetToken}`;
     const emailContent: string = composeResetEmailContent(resetURL);
     const wasEmailSent: boolean = await sendEmail(email, emailContent);
 


### PR DESCRIPTION
Agora o link enviado ao email está totalmente de acordo com o Frontend (que agora implementou a página).