### PR TITLE
Chore/Fix: Adiciona exceção no ESLint para try catch errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,12 @@ module.exports = {
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        argsIgnorePattern: '^err|^error|^_'
+      }
+    ],
     'prettier/prettier': [
       'error',
       {


### PR DESCRIPTION
Muitas variáveis do tipo error não são lançadas no projeto, sendo tratadas de maneiras personalizadas. Dezenas delas recebem warning quando o docker roda o projeto.

Eu adicionei uma exceção para esses casos de erro a fim de limpar essa poluição de mensagens que atrapalha quando um erro realmente ocorre.