### PR TITLE
Middleware que trata de requisições com JSON inválido

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { swaggerConfig } from './config/swagger';
 import routes from './routes';
 import cron from 'node-cron';
 import { sendNewsletter } from './utils/newsletter';
+import { invalidJSONHandler } from './middleware/invalidJSONHandler';
 
 MongoDBDataSource.initialize()
   .then(() => {
@@ -25,6 +26,7 @@ const app = express();
 
 app.use(helmet());
 app.use(express.json());
+app.use(invalidJSONHandler);
 app.use(cors({ origin: true }));
 app.use(routes);
 

--- a/src/middleware/invalidJSONHandler.ts
+++ b/src/middleware/invalidJSONHandler.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware para tratamento de JSON inválido
+ * @param error O erro gerado pelo express em caso de JSON inválido gerando erro de sintaxe
+ * @param _req A requisição
+ * @param res A resposta da requisição
+ * @param next O próximo middleware a ser executado
+ * @returns Uma resposta com erro ou executa o próximo middleware
+ */
+export const invalidJSONHandler = (
+  error: Error,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): Response | void => {
+  if (error instanceof SyntaxError) {
+    return res.status(400).json({
+      status: false,
+      data: {
+        message: 'Um JSON inválido foi enviado na requisição.'
+      }
+    });
+  }
+
+  next();
+};


### PR DESCRIPTION
Cria e usa o Handler de JSON inválido, que trata os erros gerados quando a requisição envia um JSON com sintaxe quebrada ou nem mesmo envia um JSON, de modo que uma resposta facilmente legível é agora retornada ao cliente.

https://trello.com/c/BShZim98