### PR TITLE
ESLint Unused Vars - Especifica Padrões argsIgnorePattern com terminações: ^ ... $

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {
-        argsIgnorePattern: '^err|^error|^_'
+        argsIgnorePattern: '^err$|^error$|^_'
       }
     ],
     'prettier/prettier': [

--- a/src/utils/newsletter.ts
+++ b/src/utils/newsletter.ts
@@ -134,7 +134,7 @@ export const sendBulkNewsletterEmails = async (
 
       const email: string = user.email;
       const subject: string = 'Explorando Marte - Newsletter';
-      const unsubscribeURL: string = `${process.env.FRONTEND_URL}/newsletter/unsubscribe/${unsubToken}`;
+      const unsubscribeURL: string = `${process.env.FRONTEND_URL}/auth/newsletter/unsubscribe/${unsubToken}`;
 
       const content: string = composeNewsletterEmailContent(
         unsubscribeURL,


### PR DESCRIPTION
Com relação às variáveis que são ignoradas na checagem de unused variables warnings, os padrões são agora fixados, ou seja, não analisam somente o início das variáveis, o que poderia lançar falsos positivos.

Exemplo: antes a variável _erradicated_ seria ignorada, pois começa com _err_. Agora isso não ocorre mais.

OBS: O padrão universal de ignorar variáveis que começam por \_ (underscore) continua valendo.