### PR TITLE
Remove isVerified da documentação dos parâmetros no Swagger

### DIFF
--- a/src/controller/RegisterController.ts
+++ b/src/controller/RegisterController.ts
@@ -35,9 +35,6 @@ export class RegisterController {
    *               isSubscribed:
    *                 type: boolean
    *                 description: Indica se o usuário está inscrito na newsletter ou não
-   *               isVerified:
-   *                 type: boolean
-   *                 description: Indica se o usuário está verificado ou não
    *     produces:
    *       - application/json
    *     consumes:

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -49,5 +49,4 @@ export interface RegisterRequestBody {
   email: string;
   password: string;
   isSubscribed: boolean;
-  isVerified: boolean;
 }


### PR DESCRIPTION
Remove isVerified da documentação e do tipo da requisição para tornar a documentação mais coerente, pois ele já foi removido do corpo da requisição.